### PR TITLE
docs(README): remove early development warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 </div>
 
-> ⚠️ **Early Development** — API may change. 
-
 ## What is Vectorless?
 
 **Vectorless** is a Rust library for querying structured documents using natural language — without vector databases or embedding models.


### PR DESCRIPTION
- Remove the "Early Development" warning that indicated API may change
- Keep the main description of Vectorless as a Rust library for querying structured documents using natural language without vector databases