### PR TITLE
docs(README): center image and update examples reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **Vectorless** is an ultra-performant reasoning-native document intelligence engine for AI, with the core written in Rust. It transforms documents into rich semantic trees and uses LLMs to intelligently traverse the hierarchy — retrieving the most relevant content through structural reasoning and deep contextual understanding.
 
-<img src="https://raw.githubusercontent.com/vectorlessflow/vectorless/main/docs/design/positioning.svg" alt="Vectorless" width="550">
+<div align="center"><img src="https://raw.githubusercontent.com/vectorlessflow/vectorless/main/docs/design/positioning.svg" alt="Vectorless" width="550" height="550"></div>
 
 
 ## Quick Start
@@ -88,7 +88,7 @@ async fn main() -> vectorless::Result<()> {
 </details>
 
 ## Examples
-See [examples/](examples/) for more Rust patterns — streaming, document graph, custom pilot, cross-document retrieval, and more.|
+See [examples](examples/) for more and stay tuned.
 
 ## Contributing
 

--- a/docs/design/logo-title.svg
+++ b/docs/design/logo-title.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 420 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <image href="https://raw.githubusercontent.com/vectorlessflow/vectorless/main/docs/design/lovable-vectorless.png" x="0" y="0" width="100" height="100" preserveAspectRatio="xMidYMid meet"/>
+  <text x="120" y="68" font-family="'Nunito', 'Quicksand', 'Varela Round', 'Avenir', 'Montserrat', sans-serif" font-size="52" font-weight="800" fill="#AF788B" letter-spacing="-1">Vectorless</text>
+</svg>


### PR DESCRIPTION
- Center the positioning diagram using div alignment
- Update image tag to include height attribute
- Revise examples section to remove outdated content reference
- Add new logo-title.svg file for project branding