### PR TITLE
docs(README): remove redundant badges and fix download badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@
 <h1>Reasoning-native Document Intelligence Engine</h1>
 
 [![PyPI](https://img.shields.io/pypi/v/vectorless.svg)](https://pypi.org/project/vectorless/)
-[![Python](https://img.shields.io/pypi/pyversions/vectorless.svg)](https://pypi.org/project/vectorless/)
 [![PyPI Downloads](https://static.pepy.tech/badge/vectorless/month)](https://pepy.tech/projects/vectorless)
 [![Crates.io](https://img.shields.io/crates/v/vectorless.svg)](https://crates.io/crates/vectorless)
-[![Crates.io Downloads](https://img.shields.io/crates/v/vectorless.svg)](https://crates.io/crates/vectorless)
+[![Crates.io Downloads](https://img.shields.io/crates/d/vectorless.svg)](https://crates.io/crates/vectorless)
 [![Docs](https://docs.rs/vectorless/badge.svg)](https://docs.rs/vectorless)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org/)
 
 </div>
 


### PR DESCRIPTION
- Remove Python version badge as it's not relevant
- Remove redundant Crates.io version badge
- Fix Crates.io downloads badge to use correct endpoint (.d instead of .v)
- Remove Rust version badge as it's not needed