### PR TITLE
chore(release): bump workspace version to 0.1.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rust", "python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 authors = ["zTgx <beautifularea@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
- Update workspace package version from 0.1.22 to 0.1.23