### PR TITLE
docs: update documentation URL in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
 [project.urls]
 Homepage = "https://vectorless.dev"
 Repository = "https://github.com/vectorlessflow/vectorless"
-Documentation = "https://docs.rs/vectorless"
+Documentation = "https://www.vectorless.dev/docs/intro"
 
 [tool.maturin]
 python-source = "python"


### PR DESCRIPTION
- Change documentation URL from https://docs.rs/vectorless
- Update to https://www.vectorless.dev/docs/intro