### PR TITLE
chore(release): bump version to 0.1.25 for Rust workspace and 0.1.4 f…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rust", "python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 authors = ["zTgx <beautifularea@gmail.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "vectorless"
-version = "0.1.3"
+version = "0.1.4"
 description = "Hierarchical document intelligence without vectors"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
…or Python package

- Update workspace.package.version in Cargo.toml from 0.1.24 to 0.1.25
- Update project.version in pyproject.toml from 0.1.3 to 0.1.4