### PR TITLE
refactor(rust): reorder imports and improve code formatting

### DIFF
--- a/rust/src/index/summary/strategy.rs
+++ b/rust/src/index/summary/strategy.rs
@@ -6,8 +6,8 @@
 use async_trait::async_trait;
 
 use crate::document::{DocumentTree, NodeId};
-use crate::llm::{LlmClient, LlmResult};
 use crate::llm::memo::{MemoKey, MemoStore, MemoValue};
+use crate::llm::{LlmClient, LlmResult};
 use crate::utils::fingerprint::Fingerprint;
 
 /// Configuration for summary strategies.

--- a/rust/src/llm/executor.rs
+++ b/rust/src/llm/executor.rs
@@ -61,8 +61,8 @@ use async_openai::types::chat::{
 use super::config::LlmConfig;
 use super::error::{LlmError, LlmResult};
 use super::fallback::{FallbackChain, FallbackStep};
-use crate::metrics::MetricsHub;
 use super::throttle::ConcurrencyController;
+use crate::metrics::MetricsHub;
 
 /// Unified executor for LLM operations.
 ///

--- a/rust/src/llm/memo/store.rs
+++ b/rust/src/llm/memo/store.rs
@@ -426,7 +426,8 @@ impl MemoStore {
         }
 
         // Restore stats
-        self.stats.load_from(data.stats.hits, data.stats.misses, data.stats.tokens_saved);
+        self.stats
+            .load_from(data.stats.hits, data.stats.misses, data.stats.tokens_saved);
 
         info!(
             "Loaded memo store with {} entries from {:?}",

--- a/rust/src/llm/pool.rs
+++ b/rust/src/llm/pool.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use super::client::LlmClient;
 use super::config::LlmConfig;
 use super::fallback::{FallbackChain, FallbackConfig};
-use crate::metrics::MetricsHub;
 use super::throttle::ConcurrencyController;
+use crate::metrics::MetricsHub;
 
 /// Pool of LLM clients for different purposes.
 ///

--- a/rust/src/retrieval/complexity/detector.rs
+++ b/rust/src/retrieval/complexity/detector.rs
@@ -60,8 +60,7 @@ impl ComplexityDetector {
         }
 
         let result = if let Some(ref client) = self.llm_client {
-            if let Some(complexity) =
-                crate::retrieval::pilot::detect_with_llm(client, query).await
+            if let Some(complexity) = crate::retrieval::pilot::detect_with_llm(client, query).await
             {
                 complexity
             } else {

--- a/rust/src/retrieval/decompose.rs
+++ b/rust/src/retrieval/decompose.rs
@@ -47,8 +47,8 @@
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-use crate::llm::{LlmClient, LlmExecutor};
 use crate::llm::memo::{MemoKey, MemoOpType, MemoStore, MemoValue};
+use crate::llm::{LlmClient, LlmExecutor};
 use crate::utils::fingerprint::Fingerprint;
 
 /// Sub-query resulting from decomposition.
@@ -269,30 +269,27 @@ impl QueryDecomposer {
         info!("Decomposing complex query: '{}'", query);
 
         // Try LLM-based decomposition if available
-        let result = if self.config.use_llm && (self.llm_client.is_some() || self.llm_executor.is_some()) {
-            match self.llm_decompose(query).await {
-                Ok(result) => result,
-                Err(e) => {
-                    debug!(
-                        "LLM decomposition failed, falling back to rule-based: {}",
-                        e
-                    );
-                    self.rule_based_decompose(query)?
+        let result =
+            if self.config.use_llm && (self.llm_client.is_some() || self.llm_executor.is_some()) {
+                match self.llm_decompose(query).await {
+                    Ok(result) => result,
+                    Err(e) => {
+                        debug!(
+                            "LLM decomposition failed, falling back to rule-based: {}",
+                            e
+                        );
+                        self.rule_based_decompose(query)?
+                    }
                 }
-            }
-        } else {
-            self.rule_based_decompose(query)?
-        };
+            } else {
+                self.rule_based_decompose(query)?
+            };
 
         // Cache the result
         if let Some(ref store) = self.memo_store {
             let cache_key = Self::build_cache_key(query);
             if let Ok(json) = serde_json::to_value(&CachedDecomposition::from_result(&result)) {
-                store.put_with_tokens(
-                    cache_key,
-                    MemoValue::Json(json),
-                    (query.len() / 4) as u64,
-                );
+                store.put_with_tokens(cache_key, MemoValue::Json(json), (query.len() / 4) as u64);
             }
         }
 

--- a/rust/src/retrieval/pilot/llm_pilot.rs
+++ b/rust/src/retrieval/pilot/llm_pilot.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use crate::document::{DocumentTree, NodeId};
-use crate::llm::{LlmClient, LlmExecutor};
 use crate::llm::memo::{MemoKey, MemoStore, MemoValue};
+use crate::llm::{LlmClient, LlmExecutor};
 use crate::utils::fingerprint::Fingerprint;
 
 use super::budget::BudgetController;

--- a/rust/src/retrieval/stages/analyze.rs
+++ b/rust/src/retrieval/stages/analyze.rs
@@ -164,7 +164,8 @@ impl AnalyzeStage {
         self.complexity_detector = detector;
 
         // Also enable query decomposition
-        let mut decomposer = QueryDecomposer::new(DecompositionConfig::default()).with_llm_client(client);
+        let mut decomposer =
+            QueryDecomposer::new(DecompositionConfig::default()).with_llm_client(client);
         if let Some(ref store) = self.memo_store {
             decomposer = decomposer.with_memo_store(store.clone());
         }

--- a/rust/src/retrieval/sufficiency/llm_judge.rs
+++ b/rust/src/retrieval/sufficiency/llm_judge.rs
@@ -171,11 +171,7 @@ Be conservative - only mark as sufficient if you're confident the content answer
         if let Some(ref store) = self.memo_store {
             let cache_key = self.build_cache_key(query, content);
             let tokens = (prompt.len() / 4) as u64;
-            store.put_with_tokens(
-                cache_key,
-                MemoValue::Text(format!("{:?}", result)),
-                tokens,
-            );
+            store.put_with_tokens(cache_key, MemoValue::Text(format!("{:?}", result)), tokens);
         }
 
         result


### PR DESCRIPTION
Reorder import statements in multiple files to maintain consistency and improve readability. Also fix line wrapping issues in several places to keep lines under 100 characters.

BREAKING CHANGE: None

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] Code compiles (`cargo build`)
- [ ] Tests pass (`cargo test --lib --all-features`)
- [ ] No new clippy warnings (`cargo clippy --all-features`)
- [ ] Public APIs have documentation comments
- [ ] Python bindings updated (if Rust API changed)

## Notes

<!-- Anything reviewers should know? Breaking changes, migration notes, etc. -->
