### PR TITLE
refactor(rust): format code with proper line breaks

### DIFF
--- a/rust/src/agent/tools/worker/ls.rs
+++ b/rust/src/agent/tools/worker/ls.rs
@@ -55,7 +55,9 @@ pub fn ls(ctx: &DocContext, state: &WorkerState) -> ToolResult {
             ToolResult::ok(output)
         }
         None => {
-            output.push_str("(no navigation data for this node)\nUse cat to read content or cd .. to go back.");
+            output.push_str(
+                "(no navigation data for this node)\nUse cat to read content or cd .. to go back.",
+            );
             ToolResult::ok(output)
         }
     }

--- a/rust/src/agent/worker/execute.rs
+++ b/rust/src/agent/worker/execute.rs
@@ -224,7 +224,11 @@ fn truncate_log(s: &str) -> std::borrow::Cow<'_, str> {
     if s.len() <= MAX {
         std::borrow::Cow::Borrowed(s)
     } else {
-        std::borrow::Cow::Owned(format!("{}...(truncated, {} chars total)", &s[..MAX], s.len()))
+        std::borrow::Cow::Owned(format!(
+            "{}...(truncated, {} chars total)",
+            &s[..MAX],
+            s.len()
+        ))
     }
 }
 

--- a/rust/src/agent/worker/mod.rs
+++ b/rust/src/agent/worker/mod.rs
@@ -210,9 +210,7 @@ impl<'a> Agent for Worker<'a> {
                     .await
                     .map_err(|e| Error::LlmReasoning {
                         stage: "worker/navigation".to_string(),
-                        detail: format!(
-                            "Nav loop LLM call failed (round {round_num}): {e}"
-                        ),
+                        detail: format!("Nav loop LLM call failed (round {round_num}): {e}"),
                     })?;
             llm_calls += 1;
 

--- a/rust/src/client/engine.rs
+++ b/rust/src/client/engine.rs
@@ -477,8 +477,8 @@ impl Engine {
     /// as the retrieval agent progresses through navigation.
     ///
     /// Supports single-document and multi-document scope.
-    /// Events are translated from the agent's internal [`AgentEvent`](crate::agent::AgentEvent)
-    /// into the public [`RetrieveEvent`] stream.
+    /// Events are translated from the agent's internal event stream
+    /// into the public `RetrieveEventReceiver` stream.
     pub async fn query_stream(&self, ctx: QueryContext) -> Result<RetrieveEventReceiver> {
         self.check_cancel()?;
         let _guard = self.inc_active();
@@ -1073,7 +1073,10 @@ impl Engine {
 
         // Load all documents in parallel and extract keyword profiles
         let doc_ids = self.workspace.inner().list_documents().await;
-        info!(doc_count = doc_ids.len(), "Loading documents for graph rebuild");
+        info!(
+            doc_count = doc_ids.len(),
+            "Loading documents for graph rebuild"
+        );
         let concurrency = self.config.llm.throttle.max_concurrent_requests;
 
         let loaded: Vec<Option<PersistedDocument>> = futures::stream::iter(doc_ids.iter().cloned())
@@ -1101,7 +1104,11 @@ impl Engine {
         }
 
         let graph = builder.build();
-        info!(nodes = graph.node_count(), edges = graph.edge_count(), "Graph built, persisting");
+        info!(
+            nodes = graph.node_count(),
+            edges = graph.edge_count(),
+            "Graph built, persisting"
+        );
         self.workspace.set_graph(&graph).await?;
         Ok(())
     }


### PR DESCRIPTION
- Format long string concatenation in ls tool to stay within 100 char limit
- Split format! macro calls across multiple lines for better readability
- Condense error formatting in worker navigation to single line
- Update documentation comments to reference correct types
- Format logging statements with proper line breaks for doc count
- Format logging statements with proper line breaks for graph stats

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] Code compiles (`cargo build`)
- [ ] Tests pass (`cargo test --lib --all-features`)
- [ ] No new clippy warnings (`cargo clippy --all-features`)
- [ ] Public APIs have documentation comments
- [ ] Python bindings updated (if Rust API changed)

## Notes

<!-- Anything reviewers should know? Breaking changes, migration notes, etc. -->
