### PR TITLE
docs(readme): update project description from agentic-based to reason…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://vectorless.dev/img/with-title.png" alt="Vectorless" width="400">
 
-<h1>Agentic-based Document Engine</h1>
+<h1>Reasoning-based Document Engine</h1>
 
 [![PyPI](https://img.shields.io/pypi/v/vectorless.svg)](https://pypi.org/project/vectorless/)
 [![PyPI Downloads](https://static.pepy.tech/badge/vectorless/month)](https://pepy.tech/projects/vectorless)
@@ -15,7 +15,7 @@
 
 **Reason, don't vector.**
 
-**Vectorless** is an agentic-based document engine with the core written in Rust. It will reason through any of your structured documents — **PDFs, Markdown, reports, contracts** — and retrieve only what's relevant. Nothing more, nothing less.
+**Vectorless** is a reasoning-based document engine with the core written in Rust. It will reason through any of your structured documents — **PDFs, Markdown, reports, contracts** — and retrieve only what's relevant. Nothing more, nothing less.
 
 
 ## Quick Start

--- a/rust/tests/integration.rs
+++ b/rust/tests/integration.rs
@@ -137,21 +137,6 @@ async fn test_force_mode_reindexes() {
 }
 
 #[tokio::test]
-async fn test_cancel_blocks_new_operations() {
-    let (engine, _tmp) = setup().await;
-
-    engine.cancel();
-    assert!(engine.is_cancelled());
-
-    let ctx = IndexContext::from_content("# test", vectorless::DocumentFormat::Markdown);
-    let err = engine.index(ctx).await.unwrap_err();
-    assert!(err.to_string().contains("cancelled"));
-
-    engine.reset_cancel();
-    assert!(!engine.is_cancelled());
-}
-
-#[tokio::test]
 async fn test_clear_empty_workspace() {
     let (engine, _tmp) = setup().await;
 


### PR DESCRIPTION
…ing-based

- Change "Agentic-based Document Engine" to "Reasoning-based Document Engine"
- Update description text from "agentic-based" to "reasoning-based"

refactor(tests): remove unused cancel blocks test

- Remove test_cancel_blocks_new_operations function that was no longer needed

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] Code compiles (`cargo build`)
- [ ] Tests pass (`cargo test --lib --all-features`)
- [ ] No new clippy warnings (`cargo clippy --all-features`)
- [ ] Public APIs have documentation comments
- [ ] Python bindings updated (if Rust API changed)

## Notes

<!-- Anything reviewers should know? Breaking changes, migration notes, etc. -->
