### PR TITLE
chore(ci): update documentation build target and remove crate publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check documentation build
-        run: cargo doc -p vectorless --no-deps --all-features
+        run: cargo doc -p vectorless-engine --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,18 +9,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Publish Rust crate to crates.io
-  publish-crates:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Publish vectorless crate
-        run: cargo publish -p vectorless
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
   # Publish Python package to PyPI
   publish-pypi:
     name: Publish to PyPI
@@ -40,7 +28,7 @@ jobs:
   github-release:
     name: GitHub Release
     runs-on: ubuntu-latest
-    needs: [publish-crates, publish-pypi]
+    needs: [publish-pypi]
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
- Change documentation build target from 'vectorless' to 'vectorless-engine'
- Remove the publish-crates job that published to crates.io
- Update github-release job dependencies to only depend on publish-pypi

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] Code compiles (`cargo build`)
- [ ] Tests pass (`cargo test --lib --all-features`)
- [ ] No new clippy warnings (`cargo clippy --all-features`)
- [ ] Public APIs have documentation comments
- [ ] Python bindings updated (if Rust API changed)

## Notes

<!-- Anything reviewers should know? Breaking changes, migration notes, etc. -->
