### PR TITLE
refactor(docs): remove redundant documentation links from homepage

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -49,7 +49,6 @@ export default function Home(): ReactNode {
                   <code>pip install vectorless</code>
                 </div>
                 <div className={styles.productLinks}>
-                  <Link to="/docs/getting-started">Documentation</Link>
                   <Link href="https://github.com/vectorlessflow/vectorless">GitHub</Link>
                 </div>
               </div>
@@ -69,7 +68,6 @@ export default function Home(): ReactNode {
                   <code>pip install vectorless-code</code>
                 </div>
                 <div className={styles.productLinks}>
-                  <Link to="/docs/vectorless-code">Learn more</Link>
                   <Link href="https://github.com/vectorlessflow/vectorless-code">GitHub</Link>
                 </div>
               </div>


### PR DESCRIPTION
- Remove "Documentation" link from vectorless product section
- Remove "Learn more" link from vectorless-code product section
- Keep only GitHub links for both products to streamline navigation

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] Code compiles (`cargo build`)
- [ ] Tests pass (`cargo test --lib --all-features`)
- [ ] No new clippy warnings (`cargo clippy --all-features`)
- [ ] Public APIs have documentation comments
- [ ] Python bindings updated (if Rust API changed)

## Notes

<!-- Anything reviewers should know? Breaking changes, migration notes, etc. -->
