### PR TITLE
refactor(python): reorder imports and improve error handling formatting

### DIFF
--- a/crates/vectorless-py/src/document.rs
+++ b/crates/vectorless-py/src/document.rs
@@ -5,8 +5,8 @@
 
 use std::sync::Arc;
 
-use pyo3::prelude::*;
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 use tokio::sync::Mutex;
 
@@ -380,9 +380,7 @@ impl PyDocument {
         future_into_py(py, async move {
             let num = node_id
                 .strip_prefix('n')
-                .ok_or_else(|| {
-                    PyRuntimeError::new_err("NodeId must start with 'n'")
-                })?
+                .ok_or_else(|| PyRuntimeError::new_err("NodeId must start with 'n'"))?
                 .parse::<u64>()
                 .map_err(|_| PyRuntimeError::new_err("Invalid NodeId"))?;
             let nav = nav.lock().await;
@@ -401,9 +399,7 @@ impl PyDocument {
         future_into_py(py, async move {
             let num = node_id
                 .strip_prefix('n')
-                .ok_or_else(|| {
-                    PyRuntimeError::new_err("NodeId must start with 'n'")
-                })?
+                .ok_or_else(|| PyRuntimeError::new_err("NodeId must start with 'n'"))?
                 .parse::<u64>()
                 .map_err(|_| PyRuntimeError::new_err("Invalid NodeId"))?;
             let nav = nav.lock().await;
@@ -422,9 +418,7 @@ impl PyDocument {
         future_into_py(py, async move {
             let num = node_id
                 .strip_prefix('n')
-                .ok_or_else(|| {
-                    PyRuntimeError::new_err("NodeId must start with 'n'")
-                })?
+                .ok_or_else(|| PyRuntimeError::new_err("NodeId must start with 'n'"))?
                 .parse::<u64>()
                 .map_err(|_| PyRuntimeError::new_err("Invalid NodeId"))?;
             let nav = nav.lock().await;

--- a/crates/vectorless-py/src/engine.rs
+++ b/crates/vectorless-py/src/engine.rs
@@ -3,8 +3,8 @@
 
 //! Engine Python wrapper — async compile/forget/list_documents.
 
-use pyo3::prelude::*;
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -73,7 +73,9 @@ async fn run_load_document(engine: Arc<Engine>, doc_id: String) -> PyResult<PyDo
             let navigator = vectorless_primitives::DocumentNavigator::new(d);
             Ok(PyDocument::from_navigator(navigator))
         }
-        None => Err(PyRuntimeError::new_err(format!("Document not found: {doc_id}"))),
+        None => Err(PyRuntimeError::new_err(format!(
+            "Document not found: {doc_id}"
+        ))),
     }
 }
 
@@ -166,9 +168,8 @@ impl PyEngine {
             builder.build().await
         });
 
-        let engine = engine.map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to create engine: {}", e))
-        })?;
+        let engine = engine
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to create engine: {}", e)))?;
 
         Ok(Self {
             inner: Arc::new(engine),


### PR DESCRIPTION
Reorder pyo3 imports in document.rs and engine.rs for consistency. Format error handling code to stay within 100 character line limits and improve readability.

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] Code compiles (`cargo build`)
- [ ] Tests pass (`cargo test --lib --all-features`)
- [ ] No new clippy warnings (`cargo clippy --all-features`)
- [ ] Public APIs have documentation comments
- [ ] Python bindings updated (if Rust API changed)

## Notes

<!-- Anything reviewers should know? Breaking changes, migration notes, etc. -->
