### PR TITLE
refactor(engine): use get_runtime instead of creating new Runtime

### DIFF
--- a/crates/vectorless-py/src/engine.rs
+++ b/crates/vectorless-py/src/engine.rs
@@ -5,9 +5,8 @@
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3_async_runtimes::tokio::future_into_py;
+use pyo3_async_runtimes::tokio::{future_into_py, get_runtime};
 use std::sync::Arc;
-use tokio::runtime::Runtime;
 
 use ::vectorless_engine::{Engine, EngineBuilder, IngestInput, RawNodeInput};
 
@@ -142,9 +141,7 @@ impl PyEngine {
         endpoint: Option<String>,
         config: Option<PyRef<super::config::PyConfig>>,
     ) -> PyResult<Self> {
-        let rt = Runtime::new().map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to create tokio runtime: {}", e))
-        })?;
+        let rt = get_runtime();
 
         let rust_config = config.map(|c| c.inner.clone());
 


### PR DESCRIPTION
Replace manual Runtime creation with get_runtime from pyo3_async_runtimes to properly integrate with the existing async runtime in Python context. This removes the dependency on tokio::runtime::Runtime and simplifies the async execution setup.

BREAKING CHANGE: The engine now relies on the existing Python async runtime instead of creating its own Tokio runtime.

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] Code compiles (`cargo build`)
- [ ] Tests pass (`cargo test --lib --all-features`)
- [ ] No new clippy warnings (`cargo clippy --all-features`)
- [ ] Public APIs have documentation comments
- [ ] Python bindings updated (if Rust API changed)

## Notes

<!-- Anything reviewers should know? Breaking changes, migration notes, etc. -->
