### PR TITLE
docs(README): remove outdated architecture explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,6 @@ async def main():
 asyncio.run(main())
 ```
 
-## How it works
-
-Vectorless splits document understanding into two layers:
-
-- **Compile (Rust).** Documents are parsed and run through a multi-pass compile pipeline (`crates/vectorless-compiler/`) that builds a navigable tree plus retrieval-acceleration artifacts (concepts, navigation hints, reasoning chains, overlap maps). The output is a `DocumentNavigator` (`crates/vectorless-primitives/`) exposed to Python over PyO3.
-- **Ask (Python).** Queries are answered by an LLM-driven reasoning loop (`vectorless/ask/`) — a Query Plan, an Orchestrator running Worker agents that issue shell-style navigation commands (`ls`, `cd`, `cat`, `grep`, `find`, `head`, `wc`, `chain`) against the compiled document, evidence evaluation with replanning, and a rerank+synthesize step.
-
 ## Help
 
 See [documentation](https://vectorless.dev/docs/getting-started) for more details.


### PR DESCRIPTION
Remove the "How it works" section that contained outdated information about the Vectorless architecture, including the Rust compilation layer and Python query processing details.

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

-

## Checklist

- [ ] Code compiles (`cargo build`)
- [ ] Tests pass (`cargo test --lib --all-features`)
- [ ] No new clippy warnings (`cargo clippy --all-features`)
- [ ] Public APIs have documentation comments
- [ ] Python bindings updated (if Rust API changed)

## Notes

<!-- Anything reviewers should know? Breaking changes, migration notes, etc. -->
